### PR TITLE
chore: update Go version from 1.21.4 to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vpsieinc/govpsie
 
-go 1.21.4
+go 1.25.0
 
 require golang.org/x/oauth2 v0.15.0
 


### PR DESCRIPTION
## Summary
- Update Go minimum version from 1.21.4 to 1.25.0 in `go.mod`
- Go 1.21 is EOL and no longer receives security updates

## Test plan
- [x] `go mod tidy` runs successfully
- [x] `go build ./...` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)